### PR TITLE
lib: remove process_exec macro to enable stable support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![feature(process_exec)]
-
 #[macro_use]
 extern crate chan;
 


### PR DESCRIPTION
I'm not sure what the "process_exec" flag was used for, however it prevents tty-rs from building on a stable channel.

If I remove it, it still buids, and the example still runs.

Was it required for an earlier version of Rust, but is no longer required?